### PR TITLE
Fix minimum length for uniform matrix types

### DIFF
--- a/lib/create-uniforms.js
+++ b/lib/create-uniforms.js
@@ -115,7 +115,7 @@ function createUniformWrapper(gl, program, uniforms, locations) {
             return dup(d, false)
           }
           return dup(d)
-        } else if(type.charAt(0) === "m" && type.length <= 5) {
+        } else if(type.charAt(0) === "m" && type.length <= 4) {
           var d = type.charCodeAt(type.length-1) - 48
           if(d < 2 || d > 4) {
             throw new Error("Invalid uniform dimension type for matrix " + name + ": " + type)


### PR DESCRIPTION
Wasn't able to declare `uniform mat4 variable;` otherwise. Thanks! :)
