### PR TITLE
Fix property names in create-attributes.js

### DIFF
--- a/lib/create-attributes.js
+++ b/lib/create-attributes.js
@@ -37,11 +37,11 @@ Object.defineProperty(proto, "location", {
     return this._location
   }
   , set: function(v) {
-    if(v !== this.location) {
+    if(v !== this._location) {
       this._location = v
-      this.gl.bindAttribLocation(this._program, v, this._name)
-      this.gl.linkProgram(this._program)
-      this.relink()
+      this._gl.bindAttribLocation(this._program, v, this._name)
+      this._gl.linkProgram(this._program)
+      this._relink()
     }
   }
 })


### PR DESCRIPTION
The getter for `attributes[name].location` had a few property names missing an underscore. Thanks! :)
