### PR TITLE
Add .dispose() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,5 +128,11 @@ console.log(shader.types)
 
 This reflects the uniform and attribute parameters that were passed to the shader constructor.
 
+## Cleanup
+
+### `shader.dispose()`
+
+Deletes the shader program and associated resources.
+
 ## Credits
 (c) 2013 Mikola Lysenko. MIT License

--- a/shader-core.js
+++ b/shader-core.js
@@ -5,16 +5,26 @@ var createAttributeWrapper = require("./lib/create-attributes.js")
 var makeReflect = require("./lib/reflect.js")
 
 //Shader object
-function Shader(gl, prog, attributes, typeInfo) {
+function Shader(gl, prog, attributes, typeInfo, vertShader, fragShader) {
   this.gl = gl
   this.handle = prog
   this.attributes = attributes
   this.types = typeInfo
+  this.vertShader = vertShader
+  this.fragShader = fragShader
 }
 
 //Binds the shader
 Shader.prototype.bind = function() {
   this.gl.useProgram(this.handle)
+}
+
+Shader.prototype.dispose = function() {
+  var gl = this.gl
+
+  gl.deleteShader(this.vertShader)
+  gl.deleteShader(this.fragShader)
+  gl.deleteProgram(this.handle)
 }
 
 //Relinks all uniforms
@@ -73,7 +83,11 @@ function createShader(
       doLink), { 
         uniforms: makeReflect(uniforms), 
         attributes: makeReflect(attributes)
-    })
+    },
+    vertShader,
+    fragShader
+  )
+
   Object.defineProperty(shader, "uniforms", createUniformWrapper(
     gl, 
     program, 


### PR DESCRIPTION
Previously, the vertex and fragment shader IDs were hidden by gl-shader-core. They’re now exposed on the shader instance so that they can be deleted and/or modified later.

The .dispose() method will delete the shaders and program on that instance.

Adding because I needed to quickly replace shaders while live-editing them – though I think it's more efficient to recompile them, and might send through another PR soon with that functionality if you're open to it :)
