### PR TITLE
Allow default attrib locations to be passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ Constructs a packaged gl-shader object with shims for all of the uniforms and at
 * `uniforms` is a list of all uniforms exported by the shader program
 * `attributes` is a list of all attributes exported by the shader program
 
-The uniform and attributes variables have output which is consistent with [glsl-extract](https://npmjs.org/package/glsl-extract)
+The uniform and attributes variables have output which is consistent with [glsl-extract](https://npmjs.org/package/glsl-extract). 
 
 **Returns** A compiled shader object.
 
+You can specify a default `location` number for each attribute, otherwise WebGL will bind it automatically. 
 
 ## Methods
 

--- a/shader-core.js
+++ b/shader-core.js
@@ -100,6 +100,13 @@ function createShader(
   var program = gl.createProgram()
   gl.attachShader(program, fragShader)
   gl.attachShader(program, vertShader)
+
+  //Optional default attriubte locations
+  attributes.forEach(function(a) {
+    if (typeof a.location === 'number') 
+      gl.bindAttribLocation(program, a.location, a.name)
+  })
+
   gl.linkProgram(program)
   if(!gl.getProgramParameter(program, gl.LINK_STATUS)) {
     var errLog = gl.getProgramInfoLog(program)


### PR DESCRIPTION
Attributes with a `location` number will be bound before the first link. 
